### PR TITLE
Refactored sceneManager to fix bug

### DIFF
--- a/engine/src/gameloop.ts
+++ b/engine/src/gameloop.ts
@@ -12,7 +12,6 @@ export class Game {
     static render_only = false;
     static time = 0;
     static start_scene: string;
-    static project_dir: string;
 
     static {
         Game.updateQueue = new Array<Updatable>();
@@ -20,7 +19,7 @@ export class Game {
 
     static start(render_only = false) {
         Game.addToUpdateQueue(SceneManager);
-        SceneManager.switchToScene(this.start_scene, this.project_dir);
+        SceneManager.switchToScene(this.start_scene);
 
         this.render_only = render_only;
         requestAnimationFrame(this.gameloop.bind(this));
@@ -52,7 +51,7 @@ export class Game {
     static loadGame(project_dir: string) {
         const fs = nw.require("fs");
 
-        this.project_dir = project_dir;
+        SceneManager.project_dir = project_dir;
         const project_file_path = project_dir + "/project.proj";
 
         // load the project json which contains all info needed to initialise the game

--- a/engine/src/sceneManager.ts
+++ b/engine/src/sceneManager.ts
@@ -8,6 +8,7 @@ const nw = (window as any).nw;
 export class SceneManager {
     static loaded_scenes: Map<string, Scene>;
     static currentScene: Scene;
+    static project_dir: string;
 
     static {
         this.loaded_scenes = new Map();
@@ -28,10 +29,9 @@ export class SceneManager {
      * Switches the current scene to the scene with the given name
      * 
      * @param scene_name The name of the scene to switch to
-     * @param project_dir The path to the root of the project
      * @param unload_current Whether to unload the current scene
      */
-    static switchToScene(scene_name: string, project_dir: string, unload_current = true) {
+    static switchToScene(scene_name: string, unload_current = true) {
         if (unload_current && this.currentScene) {
             this.currentScene.destroy();
             this.loaded_scenes.delete(this.currentScene.name);
@@ -41,7 +41,7 @@ export class SceneManager {
         if (this.loaded_scenes.has(scene_name)) {
             this.currentScene = this.loaded_scenes.get(scene_name);
         } else {
-            const path = FileUtils.findFile(scene_name + ".scene", project_dir);
+            const path = FileUtils.findFile(scene_name + ".scene", this.project_dir);
             if (!path) {
                 throw new Error("No scene found with name " + scene_name);
             }
@@ -55,11 +55,10 @@ export class SceneManager {
      * Pre-load the scene with the given name, so that it can be quickly switched to later
      * 
      * @param scene_name The name of the scene to load
-     * @param project_dir The path to the root of the project
      */
-    static preLoadScene(scene_name: string, project_dir: string) {
+    static preLoadScene(scene_name: string) {
         if (!this.loaded_scenes.has(scene_name)) {
-            const path = FileUtils.findFile(scene_name + ".scene", project_dir);
+            const path = FileUtils.findFile(scene_name + ".scene", this.project_dir);
             if (!path) {
                 throw new Error("No scene found with name " + scene_name);
             }

--- a/sugma/projects/project1/scenes/test_scene_2.scene
+++ b/sugma/projects/project1/scenes/test_scene_2.scene
@@ -1,5 +1,5 @@
 {
-    "name": "test2",
+    "name": "test_scene_2",
     "entities": [
         {
             "name": "foreground frog",

--- a/sugma/src/app/navbar/navbar.component.ts
+++ b/sugma/src/app/navbar/navbar.component.ts
@@ -42,7 +42,7 @@ export class NavbarComponent {
     };
     reader.onloadend = (_e: any) => {
       console.log(sceneName);
-      engine.SceneManager.preLoadScene(sceneName, engine.Game.project_dir);
+      engine.SceneManager.preLoadScene(sceneName);
       this.scenes = [ ...engine.SceneManager.loaded_scenes.keys() ];
     };
     reader.readAsText(file);

--- a/sugma/src/app/open-project-dialog/open-project-dialog.component.ts
+++ b/sugma/src/app/open-project-dialog/open-project-dialog.component.ts
@@ -58,7 +58,7 @@ export class OpenProjectDialogComponent {
     engine.Game.loadGame(projectPath);
     const startScene = engine.Game.start_scene;
     // preload the start scene
-    engine.SceneManager.preLoadScene(startScene, projectPath);
+    engine.SceneManager.preLoadScene(startScene);
     engine.Game.start(true);
     this.router.navigate(["/scene/" + projectJson.start_scene]);
   }

--- a/sugma/src/app/scene-tab/scene-tab.component.ts
+++ b/sugma/src/app/scene-tab/scene-tab.component.ts
@@ -55,7 +55,7 @@ export class SceneTabComponent {
 
       if (engine.SceneManager.getSceneNames().includes(this.sceneName)) {
         console.log("Loading scene " + this.sceneName);
-        engine.SceneManager.switchToScene(this.sceneName, engine.Game.project_dir, false);
+        engine.SceneManager.switchToScene(this.sceneName, false);
         this.scene = engine.SceneManager.currentScene;
       } else {
         // The scene doesn't exist, so redirect home


### PR DESCRIPTION
There was a bug where the engine would crash if you loaded a project twice. Root cause of the issue was what used to be line 100 of sceneManager.
Fixed it by requiring that loadScene be called with a path, though this required I refactor a whole bunch of other stuff to make it work.