### PR TITLE
File-manager styling + fix crash on reload

### DIFF
--- a/sugma/projects/project1/scenes/test_scene.scene
+++ b/sugma/projects/project1/scenes/test_scene.scene
@@ -1,6 +1,10 @@
 {
   "name": "test_scene",
-  "layers": ["background", "foreground", "ui"],
+  "layers": [
+    "background",
+    "foreground",
+    "ui"
+  ],
   "entities": [
     {
       "name": "frog",

--- a/sugma/src/app/file-explorer/file-explorer.component.html
+++ b/sugma/src/app/file-explorer/file-explorer.component.html
@@ -2,8 +2,7 @@
   <mat-icon *ngIf="canNavigateUp" class="pointer" (click)="navigateUp()">
     arrow_back
   </mat-icon>
-  <span style="margin-left: 8px"> {{ directory_path || "Files" }} </span>
-  <span class="spacer"></span>
+  <div class="path-wrapper"><span>{{ "&lrm;" + directory_path + "&lrm;" || "Files" }}</span></div>
   <mat-icon class="pointer" (click)="openNewFolderDialog()">
     create_new_folder
   </mat-icon>
@@ -20,46 +19,43 @@
   class="container"
   fxFlex
   fxLayout="row"
-  fxLayoutAlign="space-between stretch"
+  fxLayoutAlign="space-between"
 >
-  <div class="content" fxFlex fxLayout="row">
-    <mat-grid-list cols="6" fxFlex>
-      <mat-grid-tile
-        *ngFor="let element of fileElements"
-        class="file-or-folder"
+  <div
+    *ngFor="let element of fileElements"
+    class="file-or-folder-wrapper"
+  >
+    <span
+      [matMenuTriggerFor]="rootMenu"
+      [matMenuTriggerData]="{ element: element }"
+      #menuTrigger="matMenuTrigger"
+    >
+    </span>
+    <div
+      class="file-or-folder"
+      fxLayout="column"
+      fxLayoutAlign="space-between center"
+      (click)="navigate(element)"
+      (contextmenu)="openMenu($event, menuTrigger)"
+    >
+      <mat-icon
+        color="accent"
+        class="file-or-folder-icon pointer"
+        *ngIf="element.isFolder"
       >
-        <span
-          [matMenuTriggerFor]="rootMenu"
-          [matMenuTriggerData]="{ element: element }"
-          #menuTrigger="matMenuTrigger"
-        >
-        </span>
-        <div
-          fxLayout="column"
-          fxLayoutAlign="space-between center"
-          (click)="navigate(element)"
-          (contextmenu)="openMenu($event, menuTrigger)"
-        >
-          <mat-icon
-            color="accent"
-            class="file-or-folder-icon pointer"
-            *ngIf="element.isFolder"
-          >
-            folder
-          </mat-icon>
-          <mat-icon
-            color="primary"
-            class="file-or-folder-icon pointer"
-            *ngIf="!element.isFolder"
-          >
-            insert_drive_file
-          </mat-icon>
-          <br />
+        folder
+      </mat-icon>
+      <mat-icon
+        color="primary"
+        class="file-or-folder-icon pointer"
+        *ngIf="!element.isFolder"
+      >
+        insert_drive_file
+      </mat-icon>
+      <br />
 
-          <span width="50px">{{ element.name }}</span>
-        </div>
-      </mat-grid-tile>
-    </mat-grid-list>
+      <span [attr.title]="element.name" width="50px">{{ element.name }}</span>
+    </div>
   </div>
 </div>
 

--- a/sugma/src/app/file-explorer/file-explorer.component.scss
+++ b/sugma/src/app/file-explorer/file-explorer.component.scss
@@ -10,39 +10,46 @@
   user-select: none;
 }
 
-.mat-grid-tile{
-    text-align: center;
+.path-wrapper {
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  direction: rtl;
+  text-align: left;
+
+  span {
+    padding-left: 8px;
+    padding-right: 8px;
+  }
 }
 
-.file-or-folder {
-  padding: 8px;
+.container {
+  overflow-y: auto;
+}
+
+.file-or-folder-wrapper {
+  padding: 4px;
   overflow: hidden;
+  width: 90px;
+  display: inline-block;
+
+  .file-or-folder span {
+    display: block;
+    overflow: hidden;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }
 
 .file-or-folder-icon {
   width: 50px;
   height: 50px;
   font-size: 50px;
+  padding-left: 20px;
 }
 
 .pointer {
   cursor: pointer;
-}
-
-.spacer {
-  flex: 1 1 auto;
-}
-
-@media (min-width: 600px) {
-  .grid-list {
-    width: 500px;
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-@media (min-width: 960px) {
-  .grid-list {
-    width: 800px;
-    grid-template-columns: repeat(3, 1fr);
-  }
+  flex-shrink: 0;
 }

--- a/sugma/src/app/file-explorer/file-explorer.component.ts
+++ b/sugma/src/app/file-explorer/file-explorer.component.ts
@@ -28,13 +28,13 @@ export class FileExplorerComponent {
   @Output() navigatedDown = new EventEmitter<FileElement>()
   @Output() navigatedUp = new EventEmitter()
 
-  constructor(public dialog: MatDialog, public fileService: FileService) {
-    this.directory_path = fileService.path;
+  constructor(public dialog: MatDialog, public fileService: FileService) { }
+
+  ngOnInit() {
+    this.directory_path = this.fileService.path;
     this.listDirectory(this.directory_path);
     this.fileElements = [];
   }
-
-  ngOnInit() { }
 
   listDirectory(directory_path: string) {
     // Use Node.js fs module to read the contents of the directory

--- a/sugma/src/app/file-manager/file-manager.component.ts
+++ b/sugma/src/app/file-manager/file-manager.component.ts
@@ -17,8 +17,10 @@ export class FileManagerComponent {
   currentPath!: string;
   canNavigateUp = false;
 
-  constructor(public fileService: FileService) {
-    this.currentPath = fileService.path;
+  constructor(public fileService: FileService) { }
+
+  ngOnInit(): void {
+    this.currentPath = this.fileService.path;
   }
 
   addFolder(folder: { name: string }) {

--- a/sugma/src/app/scene-tab/scene-tab.component.scss
+++ b/sugma/src/app/scene-tab/scene-tab.component.scss
@@ -15,6 +15,7 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    min-width: 0;
 
     .temp-canvas {
         flex: 1;

--- a/sugma/src/app/services/file.service.ts
+++ b/sugma/src/app/services/file.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { FileElement } from 'app/file-explorer/model/file-element';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { v4 } from 'uuid';
+import * as engine from 'retro-engine';
 
 export interface IFileService {
   add(fileElement: FileElement): FileElement;


### PR DESCRIPTION
- Fixed crash on reload
- Truncated file names if too long (full names shown on hover)
- File-manager no longer uses mat-grid-list to make it look nicer with large widths
- No longer overflows the page if there are too many files
- Current path is truncated if too long